### PR TITLE
Fix incorrect environment variable notation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 docker build -t xv64:latest .
-docker run -v $(PWD)/bin:/src/bin -it xv64:latest
+docker run -v ${PWD}/bin:/src/bin -it xv64:latest


### PR DESCRIPTION
Hi,

Thank you for contacting us by email. Immediately trying to build your project.

So I found an error in the build script.

Getting environment variables failed because `$(PWD)` was used instead of `${PWD}`. Generally, `()` is a subshell call.

As a result, `/bin` is referenced instead of `./bin`, and `make clean` deletes all the files under `/bin` and destroys the real world system, which is very dangerous. .