### PR TITLE
implement x2APIC support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ AS = $(TOOLPREFIX)gas
 LD = $(TOOLPREFIX)ld
 OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
-CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -Wall -MD -g -ggdb -fno-omit-frame-pointer
+CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -Wall -MD -g -ggdb -fno-omit-frame-pointer -ffunction-sections
 CFLAGS += -ffreestanding -fno-common -nostdlib -Iinclude -gdwarf-2 $(XFLAGS) $(OPT)
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
 ASFLAGS = -fno-pic -gdwarf-2 -Wa,-divide -Iinclude $(XFLAGS)
@@ -167,13 +167,13 @@ ULIB = uobj/ulib.o uobj/usys.o uobj/printf.o uobj/umalloc.o uobj/string.o
 
 fs/bin/%: uobj/%.o $(ULIB)
 	@mkdir -p fs out fs/bin
-	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
+	$(LD) $(LDFLAGS) --gc-sections -N -e main -Ttext 0 -o $@ $^
 	$(OBJDUMP) -S $@ > out/$*.asm
 	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > bin/$*.sym
 
 fs/%: uobj/%.o $(ULIB)
 	@mkdir -p fs out fs/bin
-	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
+	$(LD) $(LDFLAGS) --gc-sections -N -e main -Ttext 0 -o $@ $^
 	$(OBJDUMP) -S $@ > out/$*.asm
 	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > bin/$*.sym
 
@@ -181,7 +181,7 @@ fs/forktest: uobj/forktest.o $(ULIB)
 	@mkdir -p fs
 	# forktest has less library code linked in - needs to be small
 	# in order to be able to max out the proc table.
-	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o fs/forktest uobj/forktest.o uobj/ulib.o uobj/usys.o
+	$(LD) $(LDFLAGS) --gc-sections -N -e main -Ttext 0 -o fs/forktest uobj/forktest.o uobj/ulib.o uobj/usys.o
 	$(OBJDUMP) -S fs/forktest > out/forktest.asm
 
 out/mkfs: tools/mkfs.c include/vfs.h

--- a/Makefile
+++ b/Makefile
@@ -236,12 +236,10 @@ fs.img: out/mkfs fs/LICENSE $(UPROGS) $(SUBPROGS)
 
 	dd if=/dev/zero of=bin/fs-ext2.img bs=1k count=2000
 	mkfs -t ext2 -i 1024 -b 1024 -F bin/fs-ext2.img
-	mkdir /tmp/loop
-	mount -o loop bin/fs-ext2.img /tmp/loop
-	cp -r ./fs/ /tmp/loop/
-	umount /tmp/loop
-
-
+	mkdir -p /tmp/loop
+	sudo mount -o loop bin/fs-ext2.img /tmp/loop
+	sudo cp -r ./fs/ /tmp/loop/
+	sudo umount /tmp/loop
 -include */*.d
 
 clean:
@@ -259,7 +257,7 @@ binaries : fs.img boot.img
 	cp -r fs ./bin/
 	cd ./bin/ && tar -xvzf Xv64.vmwarevm.tar.gz && rm Xv64.vmwarevm.tar.gz && cd ..
 	qemu-img convert boot.img -O vmdk bin/Xv64.vmwarevm/boot.vmdk
-	mkdir bin/artifacts
+	mkdir -p bin/artifacts
 	cp -r uobj bin/artifacts/
 	cp -r kobj bin/artifacts/
 	cp -r out bin/artifacts/

--- a/include/defs.h
+++ b/include/defs.h
@@ -78,8 +78,10 @@ int             cpunum(void);
 extern volatile uint*    lapic;
 void            lapiceoi(void);
 void            lapicinit(void);
-void            lapicstartap(uchar, uint);
 void            microdelay(int);
+void            lapicstartap(uchar, uint);
+void            lapicx2enable(uint);
+void            lapicsendipi(uint, uint);
 
 // log.c
 void            initlog(void);

--- a/include/mmu.h
+++ b/include/mmu.h
@@ -1,6 +1,8 @@
 // This file contains definitions for the
 // x86 memory management unit (MMU).
 
+#include "x86_defs.h"
+
 // Eflags register
 #define FL_CF           0x00000001      // Carry Flag
 #define FL_PF           0x00000004      // Parity Flag
@@ -23,21 +25,6 @@
 #define FL_VIF          0x00080000      // Virtual Interrupt Flag
 #define FL_VIP          0x00100000      // Virtual Interrupt Pending
 #define FL_ID           0x00200000      // ID flag
-
-// Control Register flags
-#define CR0_PE          0x00000001      // Protection Enable
-#define CR0_MP          0x00000002      // Monitor coProcessor
-#define CR0_EM          0x00000004      // Emulation
-#define CR0_TS          0x00000008      // Task Switched
-#define CR0_ET          0x00000010      // Extension Type
-#define CR0_NE          0x00000020      // Numeric Errror
-#define CR0_WP          0x00010000      // Write Protect
-#define CR0_AM          0x00040000      // Alignment Mask
-#define CR0_NW          0x20000000      // Not Writethrough
-#define CR0_CD          0x40000000      // Cache Disable
-#define CR0_PG          0x80000000      // Paging
-
-#define CR4_PSE         0x00000010      // Page size extension
 
 #define SEG_KCODE 1  // kernel code
 #define SEG_KDATA 2  // kernel data+stack

--- a/include/proc.h
+++ b/include/proc.h
@@ -18,6 +18,10 @@ struct cpu {
   // Cpu-local storage variables; see below
   void *local;
   struct proc *proc;
+
+  char name[50];               // cpuid name
+  char vendor[13];             // cpuid vendor
+  uint32 model;                // cpuid model
 };
 
 extern struct cpu cpus[NCPU];

--- a/include/types.h
+++ b/include/types.h
@@ -6,7 +6,7 @@ typedef unsigned char  uchar;
 typedef unsigned char uint8;
 typedef unsigned short uint16;
 typedef unsigned int  uint32;
-typedef unsigned long uint64;
+typedef unsigned long long uint64;
 
 //explicit-length signed ints
 typedef char int8;

--- a/include/unix/stdint.h
+++ b/include/unix/stdint.h
@@ -4,10 +4,10 @@
 typedef char int8_t;
 typedef short int16_t;
 typedef int  int32_t;
-typedef long int64_t;
+typedef long long int64_t;
 
 
 typedef unsigned char uint8_t;
 typedef unsigned short uint16_t;
 typedef unsigned int  uint32_t;
-typedef unsigned long uint64_t;
+typedef unsigned long long uint64_t;

--- a/include/x86_defs.h
+++ b/include/x86_defs.h
@@ -1,0 +1,251 @@
+// See LICENSE for license details.
+
+#ifndef _CPUDEF_H_
+#define _CPUDEF_H_
+
+/* cr0 */
+#define CR0_PG                (1 << 31)       /* Paging */
+#define CR0_CD                (1 << 30)       /* Cache Disable */
+#define CR0_NW                (1 << 29)       /* Not Write-through */
+#define CR0_AM                (1 << 18)       /* Alignment Mask */
+#define CR0_WP                (1 << 16)       /* Write Protect */
+#define CR0_NE                (1 << 5)        /* Numeric Error enable */
+#define CR0_ET                (1 << 4)        /* Extension Type */
+#define CR0_TS                (1 << 3)        /* Task Switched */
+#define CR0_EM                (1 << 2)        /* Emulation */
+#define CR0_MP                (1 << 1)        /* Monitor Coprocessor */
+#define CR0_PE                (1 << 0)        /* Protected mode Enable */
+
+/* cr2 */
+#define CR2_PFLA              -1L             /* 63:0  Page Fault Linear Address */
+
+/* cr3 */
+#define CR3_PTPA              0xffffffffff000 /* 51:12  Page Table Physical Address */
+#define CR3_PCD               (1 << 4)        /* Page-level Cache Disable */
+#define CR3_PWT               (1 << 3)        /* Page-level Write-Through */
+
+/* cr4 */
+#define CR4_PKE               (1 << 22)       /* Protection-Key-Enable */
+#define CR4_SMAP              (1 << 21)       /* Supervisor Mode Access Protection */
+#define CR4_SMEP              (1 << 20)       /* Supervisor Mode Execute Protection */
+#define CR4_OSXSAVE           (1 << 18)       /* XSAVE and Extended States-Enable */
+#define CR4_PCIDE             (1 << 17)       /* PCID Enable */
+#define CR4_FSGS              (1 << 16)       /* FSGSBASE Enable */
+#define CR4_SMXE              (1 << 14)       /* Safer Mode Extensions Enable */
+#define CR4_VMXE              (1 << 13)       /* Virtual Machine Extensions Enable */
+#define CR4_LA57              (1 << 12)       /* Five-Level Paging */
+#define CR4_UMIP              (1 << 11)       /* User-Mode Instruction Prevention */
+#define CR4_OSXMMEXCPT        (1 << 10)       /* Unmasked SIMD FP Exceptions */
+#define CR4_OSFXSR            (1 << 9)        /* FXSAVE and FXRSTOR Enable */
+#define CR4_PCE               (1 << 8)        /* Performance Counter Enable */
+#define CR4_PGE               (1 << 7)        /* Page Global Enable */
+#define CR4_MCE               (1 << 6)        /* Machine-Check Enable */
+#define CR4_PAE               (1 << 5)        /* Physical Address Extensions */
+#define CR4_PSE               (1 << 4)        /* Page Size Extensions */
+#define CR4_DE                (1 << 3)        /* Debugging Extensions */
+#define CR4_TSD               (1 << 2)        /* Time Stamp Disable */
+#define CR4_PVI               (1 << 1)        /* Protected-Mode Virtual Interrupts */
+#define CR4_VME               (1 << 0)        /* Virtual-8086 Mode Extensions */
+
+/* cr8 */
+#define CR8_TPL               0x0000000f      /* Task Priority Level [0:3] */
+
+/* ia32-efer */
+#define IA32_EFER_NXE         (1 << 11)       /* No Execute Extension */
+#define IA32_EFER_LMA         (1 << 10)       /* Long Mode Active */
+#define IA32_EFER_LME         (1 << 8)        /* Long Mode Enable */
+#define IA32_EFER_SCE         (1 << 0)        /* System Call Extension */
+
+/* eax=0x00000001; ecx */
+#define CPUID_SSE3            (1 << 0)        /* Streaming SIMD Extensions 3 (SSE3) */
+#define CPUID_PCLMULQDQ       (1 << 1)        /* GF(2^k) Carry-less multiplication */
+#define CPUID_DTES64          (1 << 2)        /* 64-bit DS Area */
+#define CPUID_MONITOR         (1 << 3)        /* MONITOR/MWAIT instructions */
+#define CPUID_DSCPL           (1 << 4)        /* CPL Qualified Debug Store */
+#define CPUID_VMX             (1 << 5)        /* Virtual Machine Extensions */
+#define CPUID_SMX             (1 << 6)        /* Safer Mode Exentions */
+#define CPUID_EST             (1 << 7)        /* Enhanced SpeedStep Technology */
+#define CPUID_TM2             (1 << 8)        /* Thermal Monitor 2 */
+#define CPUID_SSSE3           (1 << 9)        /* Supplemental Streaming SIMD Extensions 3 */
+#define CPUID_CNXT_ID         (1 << 10)       /* L1 Context ID */
+#define CPUID_SDBG            (1 << 11)       /* Silicon Debug */
+#define CPUID_FMA             (1 << 12)       /* Fused Multiply Add */
+#define CPUID_CMPXCHG16B      (1 << 13)       /* CMPXCHG16B instruction */
+#define CPUID_XTPR            (1 << 14)       /* xTPR Update Control */
+#define CPUID_PDCM            (1 << 15)       /* Perfmon and Debug Capability */
+#define CPUID_PCID            (1 << 17)       /* Process Context Identifiers */
+#define CPUID_DCA             (1 << 18)       /* Direct cache access for DMA writes */
+#define CPUID_SSE4_1          (1 << 19)       /* SSE4.1 instructions */
+#define CPUID_SSE4_2          (1 << 20)       /* SSE4.2 instructions */
+#define CPUID_X2APIC          (1 << 21)       /* x2APIC support */
+#define CPUID_MOVBE           (1 << 22)       /* MOVBE instruction */
+#define CPUID_POPCNT          (1 << 23)       /* POPCNT instruction */
+#define CPUID_TSCDT           (1 << 24)       /* TSC Deadline Timer */
+#define CPUID_AESNI           (1 << 25)       /* AESNI instructions */
+#define CPUID_XSAVE           (1 << 26)       /* XSAVE/XRSTOR/XSETBV/XGETBV and XCR0 */
+#define CPUID_OSXSAVE         (1 << 27)       /* CR4.OSXSAVE enabled to support XSAVE/XRSTOR */
+#define CPUID_AVX             (1 << 28)       /* AVX instruction extensions */
+#define CPUID_F16C            (1 << 29)       /* 16-bit floating-point conversion instructions */
+#define CPUID_RDRND           (1 << 30)	      /* RDRAND instruction */
+#define CPUID_HV              (1 << 31)       /* Running in Hypervisor */
+
+/* eax=0x00000001; edx */
+#define CPUID_FPU             (1 << 0)        /* x87 FPU */
+#define CPUID_VME             (1 << 1)        /* Virtual 8086 mode extensions */
+#define CPUID_DE              (1 << 2)        /* Debugging extensions (CR4.DE) */
+#define CPUID_PSE             (1 << 3)        /* Page Size Extension */
+#define CPUID_TSC             (1 << 4)        /* Time Stamp Counter */
+#define CPUID_MSR             (1 << 5)        /* Model-specific Registers */
+#define CPUID_PAE             (1 << 6)        /* Physical Address Extensions */
+#define CPUID_MCE             (1 << 7)        /* Machine Check Excdeptions */
+#define CPUID_CX8             (1 << 8)        /* Compare and Swap instructions */
+#define CPUID_APIC            (1 << 9)        /* Advanced Programmable Interrupt Controller */
+#define CPUID_SEP             (1 << 11)       /* SYSENTER and SYSEXIT instructions */
+#define CPUID_MTRR            (1 << 12)       /* Memory Type Range Registers */
+#define CPUID_PGE             (1 << 13)       /* Page Global bit (CR4.PGE) */
+#define CPUID_MCA             (1 << 14)       /* Machine Check Architecture */
+#define CPUID_CMOV            (1 << 15)       /* Conditional Move Instruction */
+#define CPUID_PAT             (1 << 16)       /* Page Attribute Table */
+#define CPUID_PSE36           (1 << 17)       /* 36-Bit Page Size Extension (4MiB pages) */
+#define CPUID_PSN             (1 << 18)       /* Processor Serial Number */
+#define CPUID_CLFLSH          (1 << 19)       /* CLFLUSH instruction */
+#define CPUID_DS              (1 << 21)       /* Debug store: save trace of executed jumps */
+#define CPUID_ACPI            (1 << 22)       /* Thermal Monitor and Clock MSRs */
+#define CPUID_MMX             (1 << 23)       /* MMX instructions */
+#define CPUID_FXSR            (1 << 24)       /* FXSAVE, FXRESTOR instructions (CR4.OSFXSR) */
+#define CPUID_SSE             (1 << 25)       /* SSE instructions */
+#define CPUID_SSE2            (1 << 26)       /* SSE2 instructions */
+#define CPUID_SS              (1 << 27)       /* CPU cache supports self-snoop */
+#define CPUID_HTT             (1 << 28)       /* Max APIC IDs reserved field is valid */
+#define CPUID_TM              (1 << 29)       /* Thermal monitor limits temperature */
+#define CPUID_PBE             (1 << 31)       /* Pending Break Enable */
+
+/* eax=0x00000006; eax */
+#define CPUID_ARAT            (1 << 2)        /* APIC-Timer-always-running feature */
+
+/* eax=0x00000007; ebx */
+#define CPUID_FSGSBASE        (1 << 0)        /* Access to FS and GS MSRs */
+#define CPUID_TSC_ADJ         (1 << 1)        /* TSC adjust MSR */
+#define CPUID_SGX             (1 << 2)        /* Sotware Guard Extensions */
+#define CPUID_BMI1            (1 << 3)        /* Bit Manipulation Instruction Set 1 */
+#define CPUID_HLE             (1 << 4)        /* Hardware Lock Elision */
+#define CPUID_AVX2            (1 << 5)        /* Advanced Vector Extensions 2 */
+#define CPUID_SMEP            (1 << 7)        /* Supervisor-Mode Execution Prevention */
+#define CPUID_BMI2            (1 << 8)        /* Bit Manipulation Instruction Set 2 */
+#define CPUID_ERMS            (1 << 9)        /* Enhanced REP MOVSB/STOSB */
+#define CPUID_INVPCID         (1 << 10)       /* INVPCID instruction */
+#define CPUID_RTM             (1 << 11)       /* Transactional Synchronization Extensions */
+#define CPUID_PQM             (1 << 12)       /* Platform Quality of Service Monitoring */
+#define CPUID_DFPUCSDS        (1 << 13)       /* Deprecates FPU CS and FPU DS */
+#define CPUID_MPX             (1 << 14)       /* Memory Protection Extensions */
+#define CPUID_PQE             (1 << 15)       /* Platform Quality of Service Enforcement */
+#define CPUID_AVX512F         (1 << 16)       /* AVX512 Foundation */
+#define CPUID_AVX512DQ        (1 << 17)       /* AVX512 Doubleword and Quadword Instructions */
+#define CPUID_RDSEED          (1 << 18)       /* RDSEED instruction */
+#define CPUID_ADX             (1 << 19)       /* Add-Carry Instruction Extensions */
+#define CPUID_SMAP            (1 << 20)       /* Supervisor Mode Access Prevention */
+#define CPUID_AVX512IMFA      (1 << 21)       /* AVX-512 Integer Fused Multiply-Add Instructions */
+#define CPUID_PCOMMIT         (1 << 22)       /* PCOMMIT instruction */
+#define CPUID_CLFLUSHOPT      (1 << 23)       /* CLFLUSHOPT instruction */
+#define CPUID_CLWB            (1 << 24)       /* CLWB instruction */
+#define CPUID_INTEL_PT        (1 << 25)       /* Intel Processor Tracec */
+#define CPUID_AVX512PF        (1 << 26)       /* AVX-512 Prefetch Instructions */
+#define CPUID_AVX512ER        (1 << 27)       /* AVX-512 Exponential and Reciprocal Instructions */
+#define CPUID_AVX512CD        (1 << 28)       /* AVX-512 Conflict Detection Instructions */
+#define CPUID_SHA             (1 << 29)       /* Intel SHA extensions */
+#define CPUID_AVX512BW        (1 << 30)       /* AVX-512 Byte and Word Instructions */
+#define CPUID_AVX512VL        (1 << 31)       /* AVX-512 Vector Length Extensions */
+
+/* eax=0x00000007; ecx */
+#define CPUID_PREFETCHWT1     (1 << 0)        /* PREFETCHWT1 instruction */
+#define CPUID_AVX512VBMI      (1 << 1)        /* AVX-512 Vector Bit Manipulation Instructions */
+#define CPUID_UMIP            (1 << 2)        /* User-mode Instruction Prevention */
+#define CPUID_PKU             (1 << 3)        /* Memory Protection Keys for User-mode pages */
+#define CPUID_OSPKE           (1 << 4)        /* PKU enabled by OS */
+#define CPUID_AVX512VBMI2     (1 << 6)        /* AVX-512 Vector Bit Manipulation Instructions 2 */
+#define CPUID_GFNI            (1 << 8)        /* Galois Field instructions */
+#define CPUID_VAES            (1 << 9)        /* Vector AES instruction set (VEX-256/EVEX) */
+#define CPUID_VPCLMULQDQ      (1 << 10)       /* CLMUL instruction set (VEX-256/EVEX) */
+#define CPUID_AVX512VNNI      (1 << 11)       /* AVX-512 Vector Neural Network Instructions */
+#define CPUID_AVX512BITALG    (1 << 12)       /* AVX-512 BITALG instructions */
+#define CPUID_AVX512VPOPCNTDQ (1 << 14)       /* AVX-512 Vector POPCNt Doubleword and Quadword */
+#define CPUID_MAWAU1          (1 << 17)       /* MPX Address-Width Adjust 1 */
+#define CPUID_MAWAU2          (1 << 18)       /* MPX Address-Width Adjust 2 */
+#define CPUID_MAWAU3          (1 << 19)       /* MPX Address-Width Adjust 3 */
+#define CPUID_MAWAU4          (1 << 20)       /* MPX Address-Width Adjust 4 */
+#define CPUID_MAWAU5          (1 << 21)       /* MPX Address-Width Adjust 5 */
+#define CPUID_RDPID           (1 << 22)       /* Read Processor ID */
+#define CPUID_SGX_LC          (1 << 30)       /* SGX Launch Configuration */
+
+/* eax=0x00000007; edx */
+#define CPUID_AVX512_4VNNIW   (1 << 2)        /* AVX-512 4-register Neural Network Instructions */
+#define CPUID_AVX512_4FMAPS   (1 << 3)        /* AVX-512 4-register Multiply Accumulation Single precision */
+#define CPUID_AVX512_PCONFIG  (1 << 18)       /* Platform configuration (Memory Encryption) */
+#define CPUID_SPEC_CTRL_IBRS  (1 << 26)       /* Indirect Branch Speculation Control IBRS/IBPB */
+#define CPUID_SPEC_CTRL_STIBP (1 << 27)       /* Single Thread Indirect Branch Predictor (STIBP) */
+
+/* eax=0x80000001; ecx */
+#define CPUID_LAHF_LM         (1 << 0)        /* LAHF/SAHF in long mode */
+#define CPUID_LZCNT           (1 << 5)        /* LZCNT instruction */
+#define CPUID_PREFETCHW       (1 << 8)        /* PREFETCHW instruction */
+
+/* eax=0x80000001; edx */
+#define CPUID_SYSCALL         (1 << 11)       /* SYSCALL and SYSRET instructions */
+#define CPUID_NX              (1 << 20)       /* No Execute */
+#define CPUID_PDPE1GB         (1 << 26)       /* Gigabyte pages */
+#define CPUID_RDTSCP          (1 << 27)       /* RDTSCP instruction */
+#define CPUID_LM              (1 << 29)       /* Long mode */
+
+/* eax=0x80000007; edx */
+#define CPUID_INVARIANT_TSC   (1 << 8)        /* Invariant TSC */
+
+/* MSRs */
+#define MSR_IA32_APIC_BASE                  0x0000001BU /* APIC base physical address */
+
+/* X2APIC MSRs */
+#define MSR_IA32_EXT_APIC_ID                0x00000802U	/* x2APIC ID */
+#define MSR_IA32_EXT_APIC_VERSION           0x00000803U	/* x2APIC version */
+#define MSR_IA32_EXT_APIC_TPR               0x00000808U /* x2APIC task priority */
+#define MSR_IA32_EXT_APIC_PPR               0x0000080AU /* x2APIC processor priority */
+#define MSR_IA32_EXT_APIC_EOI               0x0000080BU	/* x2APIC EOI */
+#define MSR_IA32_EXT_APIC_LDR               0x0000080DU /* x2APIC logical destination */
+#define MSR_IA32_EXT_APIC_SIVR              0x0000080FU /* x2APIC spurious interrupt vector */
+#define MSR_IA32_EXT_APIC_ISR0              0x00000810U /* x2APIC in-service register 0 */
+#define MSR_IA32_EXT_APIC_ISR1              0x00000811U /* x2APIC in-service register 1 */
+#define MSR_IA32_EXT_APIC_ISR2              0x00000812U /* x2APIC in-service register 2 */
+#define MSR_IA32_EXT_APIC_ISR3              0x00000813U /* x2APIC in-service register 3 */
+#define MSR_IA32_EXT_APIC_ISR4              0x00000814U /* x2APIC in-service register 4 */
+#define MSR_IA32_EXT_APIC_ISR5              0x00000815U /* x2APIC in-service register 5 */
+#define MSR_IA32_EXT_APIC_ISR6              0x00000816U /* x2APIC in-service register 6 */
+#define MSR_IA32_EXT_APIC_ISR7              0x00000817U /* x2APIC in-service register 7 */
+#define MSR_IA32_EXT_APIC_TMR0              0x00000818U /* x2APIC trigger mode register 0 */
+#define MSR_IA32_EXT_APIC_TMR1              0x00000819U /* x2APIC trigger mode register 1 */
+#define MSR_IA32_EXT_APIC_TMR2              0x0000081AU /* x2APIC trigger mode register 2 */
+#define MSR_IA32_EXT_APIC_TMR3              0x0000081BU /* x2APIC trigger mode register 3 */
+#define MSR_IA32_EXT_APIC_TMR4              0x0000081CU /* x2APIC trigger mode register 4 */
+#define MSR_IA32_EXT_APIC_TMR5              0x0000081DU /* x2APIC trigger mode register 5 */
+#define MSR_IA32_EXT_APIC_TMR6              0x0000081EU /* x2APIC trigger mode register 6 */
+#define MSR_IA32_EXT_APIC_TMR7              0x0000081FU /* x2APIC trigger mode register 7 */
+#define MSR_IA32_EXT_APIC_IRR0              0x00000820U /* x2APIC interrupt request register 0 */
+#define MSR_IA32_EXT_APIC_IRR1              0x00000821U /* x2APIC interrupt request register 1 */
+#define MSR_IA32_EXT_APIC_IRR2              0x00000822U /* x2APIC interrupt request register 2 */
+#define MSR_IA32_EXT_APIC_IRR3              0x00000823U /* x2APIC interrupt request register 3 */
+#define MSR_IA32_EXT_APIC_IRR4              0x00000824U /* x2APIC interrupt request register 4 */
+#define MSR_IA32_EXT_APIC_IRR5              0x00000825U /* x2APIC interrupt request register 5 */
+#define MSR_IA32_EXT_APIC_IRR6              0x00000826U /* x2APIC interrupt request register 6 */
+#define MSR_IA32_EXT_APIC_IRR7              0x00000827U /* x2APIC interrupt request register 7 */
+#define MSR_IA32_EXT_APIC_ESR               0x00000828U /* x2APIC error status */
+#define MSR_IA32_EXT_APIC_LVT_CMCI          0x0000082FU /* x2APIC LVT corrected machine check interrupt register */
+#define MSR_IA32_EXT_APIC_ICR               0x00000830U /* x2APIC interrupt command register */
+#define MSR_IA32_EXT_APIC_LVT_TIMER         0x00000832U /* x2APIC LVT timer interrupt register */
+#define MSR_IA32_EXT_APIC_LVT_THERMAL       0x00000833U /* x2APIC LVT thermal sensor interrupt register */
+#define MSR_IA32_EXT_APIC_LVT_PMI           0x00000834U /* x2APIC LVT performance monitor interrupt register */
+#define MSR_IA32_EXT_APIC_LVT_LINT0         0x00000835U /* x2APIC LVT LINT0 register */
+#define MSR_IA32_EXT_APIC_LVT_LINT1         0x00000836U /* x2APIC LVT LINT1 register */
+#define MSR_IA32_EXT_APIC_LVT_ERROR         0x00000837U /* x2APIC LVT error register */
+#define MSR_IA32_EXT_APIC_INIT_COUNT        0x00000838U /* x2APIC initial count register */
+#define MSR_IA32_EXT_APIC_CUR_COUNT         0x00000839U /* x2APIC current count  register */
+#define MSR_IA32_EXT_APIC_DIV_CONF          0x0000083EU /* x2APIC divide configuration register */
+#define MSR_IA32_EXT_APIC_SELF_IPI          0x0000083FU /* x2APIC self IPI register */
+
+#endif /* !_CPUDEF_H_ */

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -121,20 +121,20 @@ void trap(struct trapframe* tf){
 }
 
 uint8 irq_register_handler(uint16 irq, irqhandler handler) {
-	if(irq >= MAX_IRQS) {
+	if(irq - T_IRQ0 >= MAX_IRQS) {
 		return 0; //sorry
 	}
 	acquire(&irqHandlersLock);
-	irqHandlers[irq] = handler;
+	irqHandlers[irq - T_IRQ0] = handler;
 	release(&irqHandlersLock);
 	return 1;
 }
 
 irqhandler get_registered_handler(uint16 irq) {
 	irqhandler result = 0;
-	if(irq < MAX_IRQS) {
+	if(irq - T_IRQ0 < MAX_IRQS) {
 		acquire(&irqHandlersLock);
-		result = irqHandlers[irq];
+		result = irqHandlers[irq - T_IRQ0];
 		release(&irqHandlersLock);
 	}
 	return result;

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-unset REBUILD IDE_MODE DEBUG EXT2 BIG
+unset REBUILD IDE_MODE DEBUG EXT2 BIG ACCEL
 
-while getopts 'rldeb' c
+while getopts 'rldebx' c
 do
   case $c in
     r) REBUILD=TRUE ;;
@@ -10,6 +10,7 @@ do
     d) DEBUG=TRUE ;;
     e) EXT2=TRUE ;;
     b) BIG=TRUE ;;
+    x) ACCEL=TRUE ;;
   esac
 done
 
@@ -36,7 +37,9 @@ if [ -n "$IDE_MODE" ]; then
     ROOT_DISK="-hdd ./bin/$ROOT_IMG"
 fi
 CPU="-cpu phenom-v1 -smp sockets=1 -smp cores=4 -smp threads=1"
-if [ -n "$BIG" ]; then
+if [ -n "$ACCEL" ]; then
+    CPU="-machine pc,accel=kvm,kernel-irqchip=on -cpu host,vmware-cpuid-freq=on,tsc-frequency=2600000000 -smp sockets=1 -smp cores=4 -smp threads=1"
+elif [ -n "$BIG" ]; then
     CPU="-cpu IvyBridge-v2 -smp sockets=2 -smp cores=12 -smp threads=2"
 fi
 

--- a/ulib/unix/string.c
+++ b/ulib/unix/string.c
@@ -1,6 +1,7 @@
 #include "unix/string.h"
 #include "unix/stddef.h"
 #include "syscalls.h"
+#include "types.h"
 #include "x86.h"
 #include "fcntl.h"
 

--- a/user/kexts/Makefile
+++ b/user/kexts/Makefile
@@ -23,4 +23,4 @@ all: $(PROGS)
 
 %: %.c
 	$(CC) $(CFLAGS) -c -o $@.o $@.c
-	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $(FSPATH)/kexts/$@ $@.o $(ULIB)
+	$(LD) $(LDFLAGS) --gc-sections -N -e main -Ttext 0 -o $(FSPATH)/kexts/$@ $@.o $(ULIB)


### PR DESCRIPTION
this patch implements x2APIC support. it changes the order of processor initialization bringing up multiprocessor and calling `mpmain` much earlier and moving some peripheral initialization into `postinit` which still runs on CPU 0. it's more of an FYI at this point. there are a couple of ancillaries changes included in the branch such as adding `sudo` to the loop filesystem setup and adding `-p` to `mkdir` as they were required to get `make binaries` to work locally. there is also a change to make use `typedef long long uint64` otherwise `long` compiles as a 32-bit type with `-m32`.

`irq_register_handler` and `get_registered_handler` were made to subtract `T_IRQ0` so that they are consistent with the use of IRQ numbers in the other interrupt APIs. it was necessary to change `get_registered_handler` as otherwise, it would not find traps, noting that dynamic IRQs were not in use. this small patch can be added on top of this branch to test IPI support by creating a dynamic IRQ function and sending some IPIs in `mpmain`.

```
diff --git a/kernel/main.c b/kernel/main.c
index cbce2c9a7a6c..a583e3529dd1 100644
--- a/kernel/main.c
+++ b/kernel/main.c
@@ -78,6 +78,11 @@ void mpenter(void){
        mpmain();
 }
 
+static void testirq(uint16 irq)
+{
+       cprintf("cpu-%d: received interrupt: %d\n", cpu->id, irq);
+}
+
 // Common CPU setup code.
 static void mpmain(void){
        idtinit(); // load idt register
@@ -87,6 +92,9 @@ static void mpmain(void){
                cprintf("%d-way SMP kernel online.\n", ncpu);
                postinit();
                cprintf("starting scheduler\n");
+               irq_register_handler(T_IRQ0 + 5, testirq);
+               for (int i = 0; i < ncpu; i++)
+                       lapicsendipi(T_IRQ0 + 5, i);
        }
        amd64_xchg(&cpu->started, 1); // tell startothers() we're up
        scheduler(); // start running processes
```

`identcpu` and `lapicinit` have been modified to log CPU model and APIC details together during processor initialization. TSC frequency is detected on bare metal, in VMWare and KVM but it may be necessary to manually provide the TSC frequency with KVM. `microdelay` has been updated to use the TSC base frequency.

note `run.sh` has been changed to add a `-x` flag which passes `-machine pc,accel=kvm,kernel-irqchip=on -cpu host,vmware-cpuid-freq=on,tsc-frequency=2600000000` to qemu which will enable the KVM kernel module x2APIC support. 

here is the boot log after applying the patches in this branch (tested with and without x2APIC):

```
SeaBIOS (version 1.13.0-1ubuntu1.1)
Booting from Hard Disk..Xv64 UART Console 1
Freeing mem from 50 MB to 54 MB...
acpi: cpu#0 apicid 0
acpi: cpu#1 apicid 1
acpi: cpu#2 apicid 2
acpi: cpu#3 apicid 3
acpi: ioapic#0 @fec00000 id=0 base=0
cpu-0: name: Intel(R) Core(TM) i9-7980XE CPU @ 2.60GHz vendor: GenuineIntel model: 22 tscfreq: 2600
cpu-0: lapicinit: lapic#0 @fee00000, version=0x14, maxlvt=5, xapic=1, x2apic=1, bsp=1
cpu-1: name: Intel(R) Core(TM) i9-7980XE CPU @ 2.60GHz vendor: GenuineIntel model: 22 tscfreq: 2600
cpu-1: lapicinit: lapic#1 @fee00000, version=0x14, maxlvt=5, xapic=1, x2apic=1, bsp=0
cpu-2: name: Intel(R) Core(TM) i9-7980XE CPU @ 2.60GHz vendor: GenuineIntel model: 22 tscfreq: 2600
cpu-2: lapicinit: lapic#2 @fee00000, version=0x14, maxlvt=5, xapic=1, x2apic=1, bsp=0
cpu-3: name: Intel(R) Core(TM) i9-7980XE CPU @ 2.60GHz vendor: GenuineIntel model: 22 tscfreq: 2600
cpu-3: lapicinit: lapic#3 @fee00000, version=0x14, maxlvt=5, xapic=1, x2apic=1, bsp=0
Freeing mem from 54 MB to 224 MB...
4-way SMP kernel online.
CGA COLOR Console

cpu0: starting Xv64

Xv64 is Copyright (c) 1997-2021, contributors.
See LICENSE for details.
init: process loop device
probing PCI...
PCI: 0:0.0: 8086:1237: class: 6.0 (Bridge device) irq: 0
PCI: 0:1.0: 8086:7000: class: 6.1 (Bridge device) irq: 0
PCI: 0:1.1: 8086:7010: class: 1.1 (Storage controller) irq: 0
PCI: 0:1.3: 8086:7113: class: 6.80 (Bridge device) irq: 9
PCI: 0:2.0: 1234:1111: class: 3.0 (Display controller) irq: 0
PCI: 0:3.0: 8086:2922: class: 1.6 (Storage controller) irq: 11 bar5: febf1000
Intel ICH9 controller found (bus=0, slot=3, func=0, abar=0xfebf1000)
   HBA in AHCI-only mode
SATA device detected:
   port[0].sig = 101
   ipm=1, spd=1, det=3
   rebasing port...DONE
   Init success: disk(1, 0)
Detecting IDE devices:
   no IDE devices detected
Root dev: disk(1, 0)
xv6 filesystem assumed on disk(1,0)
starting scheduler
init: starting...
init: starting kidle
init: starting sh

Welcome to Xv64
~> halt
Xv64 is shutting down now. Goodbye...
```